### PR TITLE
added tests from POMDPToolbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,13 @@ Pkg.clone("https://github.com/JuliaPOMDP/FIB.jl")
 
 ```julia
 using FIB
-pomdp = MyPOMDP() # initialize POMDP
+using POMDPModels
+pomdp = TigerPOMDP() # initialize POMDP
 
 solver = FIBSolver()
 
 # run the solver
 policy = solve(solver, pomdp)
 ```
+
+FIB.jl solves problems implemented using the [POMDPs.jl interface](https://github.com/JuliaPOMDP/POMDPs.jl). See the [documentation for POMDPs.jl](http://juliapomdp.github.io/POMDPs.jl/latest/) for more information.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -24,3 +24,7 @@ v = value(policy, b)
 
 @test a
 @test isapprox(v, -24.4557, atol=1e-4)
+
+# tests from POMDPToolbox to make sure typical usage works
+test_solver(solver, BabyPOMDP())
+test_solver(solver, TigerPOMDP())


### PR DESCRIPTION
These tests I added from POMDPToolbox will help catch errors in simulating/using the interface.

As it is, the tests fail because somewhere `pomdp.discount` is used instead of `discount(pomdp)`. My recommendation would be to merge this PR and then fix that error.

I also added a line of documentation pointing to POMDPs.jl