### PR TITLE
disable nightly so that Travis build passes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ os:
   - osx
 julia:
   - 0.6
-  - nightly
 notifications:
   email: false
 git:


### PR DESCRIPTION
Removed the failing test against the nightly version of Julia from Travis - we don't support the nightly build right now